### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # analysis001
+
+This repository contains the StockAnalysisProject.
+
+## Setup
+
+Run `./setup.sh` to install the required Python dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+matplotlib
+akshare
+requests
+streamlit

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Simple setup script for Codex environment
+set -e
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Additional setup steps can be added here
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- document setup steps
- add requirements.txt
- add a setup script for installing dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c39942198833195ff6607f2b5dbaa